### PR TITLE
feat: Output Run ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </p>
 
 ## BugBug Cloud Runner
+
 Official GitHub action to run tests and suites on BugBug Cloud.
 
 > [!IMPORTANT]
@@ -42,6 +43,16 @@ Official GitHub action to run tests and suites on BugBug Cloud.
 - **Required**: No
 - **Default**: `test-results.xml`
 
+### Outputs
+
+`suiteRunId`
+
+- **Description**: The Run ID when executing passing a suiteId.
+
+`testRunId`
+
+- **Description**: The Run ID when executing passing a testId.
+
 ### Example Usage
 
 ```yaml
@@ -56,6 +67,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run BugBug Cloud Runner
+        id: run-bugbug-tests
         uses: bugbug-io/bugbug-github-action@v1.0.2
         with:
           apiToken: ${{ secrets.BUGBUG_API_TOKEN }}
@@ -64,4 +76,8 @@ jobs:
           profileName: "Your BugBug profile name"
           variables: "key1=value1,key2=value2"
           debug: "true"
+
+      - name: Getting Run Output
+        run: |
+          echo "Suite Run ID: ${{ steps.run-bugbug-tests.outputs.suiteRunId }} | Test Run ID: ${{ steps.run-bugbug-tests.outputs.testRunId }}"
 ```

--- a/README.md
+++ b/README.md
@@ -79,5 +79,6 @@ jobs:
 
       - name: Getting Run Output
         run: |
-          echo "Suite Run ID: ${{ steps.run-bugbug-tests.outputs.suiteRunId }} | Test Run ID: ${{ steps.run-bugbug-tests.outputs.testRunId }}"
+          echo "Suite Run ID: ${{ steps.run-bugbug-tests.outputs.suiteRunId }}"
+          echo "Test Run ID: ${{ steps.run-bugbug-tests.outputs.testRunId }}"
 ```

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,13 @@ inputs:
     description: "Show more data (like raw API response)."
     required: false
     default: "false"
+outputs:
+  suiteRunId:
+    description: "The Run ID when executing passing a suiteId."
+    value: ${{ steps.run-on-bugbug.outputs.suiteRunId }}
+  testRunId:
+    description: "The Run ID when executing passing a testId."
+    value: ${{ steps.run-on-bugbug.outputs.testRunId }}
 runs:
   using: "composite"
   steps:
@@ -48,6 +55,7 @@ runs:
       run: npm i -g @testrevolution/bugbug-cli@${{ inputs.version }}
 
     - name: "Run on BugBug"
+      id: run-on-bugbug
       shell: bash
       run: ${{ github.action_path }}/.github/scripts/run.sh
       env:


### PR DESCRIPTION
## Why? :thinking:

Hello everyone! How are you? For my test scenario, I need to have access to the `suiteRunId` or `testRunId` to generate a link for the test executed. So I added two new possible outputs: `suiteRunId` and `testRunId` 

## How? :technologist:

- Capturing the execution output on a variable and checking if has `suiteRunId` or `testRunId`
- Sending values to the [$GITHUB_OUTPUT](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-masking-a-generated-output-within-a-single-job) variable
- It also captures the original status that BugBug Cli resulted and exits with that status

## Result 🔢 

- You can access the outputs through `steps.<step-name>.outputs.suiteRunId` or `steps.<step-name>.outputs.testRunId`

<img width="495" alt="Screenshot 2024-05-17 at 17 46 10" src="https://github.com/bugbug-io/bugbug-github-action/assets/1427347/4bb8dabb-23ad-4eae-93ee-ef981b2b0998">

